### PR TITLE
Create empty state when user has not selected an image or phrase.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.18.95",
-        "@types/react": "^18.2.75",
-        "@types/react-dom": "^18.2.24",
         "axios": "^1.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -23,6 +21,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/react": "^18.2.75",
+        "@types/react-dom": "^18.2.24",
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.3"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.95",
-    "@types/react": "^18.2.75",
-    "@types/react-dom": "^18.2.24",
     "axios": "^1.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -42,6 +40,8 @@
     ]
   },
   "devDependencies": {
+    "@types/react": "^18.2.75",
+    "@types/react-dom": "^18.2.24",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3"

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -34,7 +34,6 @@ const GamePage: React.FunctionComponent = () => {
         <div className='flex flex-col justify-center items-center gap-4'>
           <GameTitle></GameTitle>
           <div className=' border border-white/5 bg-slate-800/25 rounded-xl p-6 text-center items-center'>
-            {/* Using AND operator to avoid the broken image void that would be displayed if the user selected a phrase before an image*/}
             {selectedCat && selectedPhrase ? (
               <div className="flex flex-col gap-2">
                 <SelectedImage source={selectedCat}></SelectedImage>

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -29,12 +29,23 @@ const GamePage: React.FunctionComponent = () => {
     }, []);
 
     return (
+      
       <div className='flex flex-col justify-center gap-8 h-dvh'>
         <div className='flex flex-col justify-center items-center gap-4'>
           <GameTitle></GameTitle>
-          <div className=' border border-white/5 bg-slate-800/25 rounded-xl p-6 items-center flex flex-col gap-2'>
-            <SelectedImage source={selectedCat}></SelectedImage>
-            <SelectedPhrase phrase={selectedPhrase}></SelectedPhrase>
+          <div className=' border border-white/5 bg-slate-800/25 rounded-xl p-6 text-center items-center'>
+            {/* Using AND operator to avoid the broken image void that would be displayed if the user selected a phrase before an image*/}
+            {selectedCat && selectedPhrase ? (
+              <div className="flex flex-col gap-2">
+                <SelectedImage source={selectedCat}></SelectedImage>
+                <SelectedPhrase phrase={selectedPhrase}></SelectedPhrase>
+              </div>
+            ) : (
+              <div className="text-white">
+                Escolha um gato e uma frase para começar!
+              </div>
+            )}
+
           </div>  
         </div>
         <CatImageList images={images} onSelectCat={(image: string) => setSelectedCat(image) }></CatImageList>


### PR DESCRIPTION
This change modifies the GamePage, adding a conditional placeholder text that appears in place of the selected image and text if both aren't selected.
An AND operator was used because it prevents the user from seeing a broken image void (that currently displays the alt text description of the image) if they were to select a phrase before an image. Therefore, the placeholder text will cease being displayed only when a combination of image+phrase is selected, and this prevents us from having to add further logic to handle an empty image selection at this point.